### PR TITLE
GHA `uses` must define `@ref`

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
       # (helper) detect if attached to triaging board
       - id: on_triaging
-        uses: conda/actions/issue-in-project
+        uses: conda/actions/issue-in-project@v1.0
         with:
           org: conda
           project: ${{ env.TRIAGING_ID }}
@@ -82,7 +82,7 @@ jobs:
           github_token: ${{ secrets.PROJECT_TOKEN }}
       # (helper) detect if attached to sprint board
       - id: on_sprint
-        uses: conda/actions/issue-in-project
+        uses: conda/actions/issue-in-project@v1.0
         with:
           org: conda
           project: ${{ env.SPRINT_ID }}


### PR DESCRIPTION
See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-a-public-action-in-a-subdirectory