### PR TITLE
Update labels action to properly combine global/local labels

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,30 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       dryrun:
-        description: "Preview changes to labels without editing them"
+        description: "dryrun: Preview changes to labels without editing them (true|false)"
         required: true
         default: "true"
 
 jobs:
-  global-labels:
+  sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: EndBug/label-sync@v2
+      - uses: kenodegard/label-sync@multiple-and-pretty
+        # uses: EndBug/label-sync@v2.0.0  # pending EndBug/label-sync#106 & EndBug/label-sync#107
         with:
-          config-file: https://raw.githubusercontent.com/conda/infra/main/.github/labels.yml
-          delete-other-labels: true
-          dry-run: ${{ github.event.inputs.dryrun }}
-
-  local-labels:
-    runs-on: ubuntu-latest
-    steps:
-      - id: has_local
-        uses: andstor/file-existence-action@v1.0.1
-        with:
-          files: .github/labels.yml
-      - uses: EndBug/label-sync@v2
-        if: steps.has_local.outputs.files_exists == 'true'
-        with:
-          config-file: .github/labels.yml
+          config-file: |
+            https://raw.githubusercontent.com/conda/infra/main/.github/labels.yml
+            .github/labels.yml
           delete-other-labels: true
           dry-run: ${{ github.event.inputs.dryrun }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,8 +12,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: kenodegard/label-sync@multiple-and-pretty
-        # uses: EndBug/label-sync@v2.0.0  # pending EndBug/label-sync#106 & EndBug/label-sync#107
+      - uses: EndBug/label-sync@v2.1.0
         with:
           config-file: |
             https://raw.githubusercontent.com/conda/infra/main/.github/labels.yml


### PR DESCRIPTION
Discovered that it would be impossible to run two separate jobs, one for "global" labels and one for "local" labels, and to also specify `delete-other-labels: true`.

Consequently I have upstreamed the necessary changes:


* EndBug/label-sync#106
* EndBug/label-sync#107 (depends on DefinitelyTyped/DefinitelyTyped#58296)

~While we wait on those changes to be accepted we will utilize my fork.~ Changes have already been merged upstream!



┆Issue is synchronized with this [Jira Task](https://anaconda.atlassian.net/browse/CONDAORG-3)
