### PR TITLE
Define labels specific to conda/infra

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,12 @@
+- name: type::development
+  color: "fff2cc"
+  description: related to developer environment setups
+  aliases: [development]
+- name: type::github
+  color: "fff2cc"
+  description: related to GitHub org administration
+  aliases: [github]
+- name: type::hosting
+  color: "fff2cc"
+  description: related to package hosting, e.g. conda-forge channel on anaconda.org
+  aliases: [hosting]


### PR DESCRIPTION
These four labels are uniquely defined for this repo, are these labels still of value to us or should they be deprecated, consolidated, or otherwise reworked?

| Label | Description |
|:-:|:--|
| ![`type::development`](https://img.shields.io/badge/-type::development-fff2cc) | related to developer environment setups |
| ![`type::github`](https://img.shields.io/badge/-type::github-fff2cc) | related to GitHub org administration |
| ![`type::hosting`](https://img.shields.io/badge/-type::hosting-fff2cc) | related to package hosting, e.g. conda-forge channel on anaconda.org |

cc: @jezdez