### PR TITLE
Remove unnecessary commit body

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,5 +19,4 @@ jobs:
         with:
           GH_PAT: ${{ secrets.SYNC_TOKEN }}
           PR_LABELS: false
-          COMMIT_BODY: Sync from infra
           CONFIG_PATH: .github/sync.yml


### PR DESCRIPTION
The commit title already contains the necessary info:
<img width="372" alt="Screen Shot 2022-01-24 at 11 43 58 AM" src="https://user-images.githubusercontent.com/4546435/150836024-16f19739-e077-4d77-806d-178590f1f9ca.png">

