### PR TITLE
Include stale workflow and update sync accordingly

### DIFF
--- a/.github/messages.yaml
+++ b/.github/messages.yaml
@@ -1,0 +1,45 @@
+stale-issue: |
+  Hi there, thank you for your contribution!
+
+  This issue has been **automatically marked as stale** because it has not had recent activity. It will be closed automatically if no further activity occurs.
+
+  If you would like this issue to remain open please:
+
+    1. Verify that you can still reproduce the issue at hand
+    2. Comment that the issue is still reproducible and include:
+      - What OS and version you reproduced the issue on
+      - What steps you followed to reproduce the issue
+
+  **NOTE:** If this issue was closed prematurely, please leave a comment.
+
+  Thanks!
+close-issue: |
+  Hi again!
+
+  This issue has been closed since it has not had recent activity.
+
+  **NOTE:** If this issue was closed prematurely, please leave a comment.
+
+  Thanks!
+
+stale-pr: |
+  Hi there, thank you for your contribution!
+
+  This pull request has been **automatically marked as stale** because it has not had recent activity. It will be closed automatically if no further activity occurs.
+
+  If you would like this pull request to remain open please:
+
+    1. Rebase and verify the changes still work
+    2. Leave a comment with the current status
+
+  **NOTE:** If this pull request was closed prematurely, please leave a comment.
+
+  Thanks!
+close-pr: |
+  Hi again!
+
+  This pull request has been closed since it has not had recent activity.
+
+  **NOTE:** If this pull request was closed prematurely, please leave a comment.
+
+  Thanks!

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,4 +1,5 @@
 group:
+  # triaging & label syncing
   - repos: |
       conda/actions
       conda/conda
@@ -22,3 +23,27 @@ group:
         dest: .github/workflows/issues.yml
       - source: .github/workflows/labels.yml
         dest: .github/workflows/labels.yml
+  # stale syncing
+  - repos: |
+      conda/actions
+      conda/ceps
+      conda/clabot-config
+      conda/conda
+      conda/conda-benchmarks
+      conda/conda-bots
+      conda/conda-build
+      conda/conda-content-trust
+      conda/conda-docs
+      conda/conda-pack
+      conda/conda-package-handling
+      conda/conda-prefix-replacement
+      conda/conda-verify
+      conda/constructor
+      conda/cookiecutter-conda-python
+      conda/issue-tracker
+      conda/menuinst
+      conda/pycosat
+      conda/schemas
+    files:
+      - source: .github/workflows/stale.yml
+        dest: .github/workflows/stale.yml

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -25,25 +25,8 @@ group:
         dest: .github/workflows/labels.yml
   # stale syncing
   - repos: |
-      conda/actions
-      conda/ceps
-      conda/clabot-config
       conda/conda
-      conda/conda-benchmarks
-      conda/conda-bots
       conda/conda-build
-      conda/conda-content-trust
-      conda/conda-docs
-      conda/conda-pack
-      conda/conda-package-handling
-      conda/conda-prefix-replacement
-      conda/conda-verify
-      conda/constructor
-      conda/cookiecutter-conda-python
-      conda/issue-tracker
-      conda/menuinst
-      conda/pycosat
-      conda/schemas
     files:
       - source: .github/workflows/stale.yml
         dest: .github/workflows/stale.yml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,27 +14,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - id: stale_issue
-        uses: KJ002/read-yaml@1.5
+      - id: read_yaml
+        uses: conda/actions/read-yaml@v22.2.0
         with:
-          file: .github/messages.yml
-          key-path: stale-issue
-      - id: close_issue
-        uses: KJ002/read-yaml@1.5
-        with:
-          file: .github/messages.yml
-          key-path: close-issue
-      - id: stale_pr
-        uses: KJ002/read-yaml@1.5
-        with:
-          file: .github/messages.yml
-          key-path: stale-pr
-      - id: close_pr
-        uses: KJ002/read-yaml@1.5
-        with:
-          file: .github/messages.yml
-          key-path: close-pr
+          path: .github/messages.yml
+          scopes: |
+            stale-issue: stale-issue
+            close-issue: close-issue
+            stale-pr: stale-pr
+            close-pr: close-pr
       - uses: actions/stale@v4
         id: stale
         with:
@@ -48,13 +36,13 @@ jobs:
           days-before-pr-close: 30
 
           # Comment on the staled issues
-          stale-issue-message: ${{ steps.stale_issue.outputs.data }}
+          stale-issue-message: ${{ steps.read_yaml.outputs.stale-issue }}
           # Comment on the staled issues while closed
-          close-issue-message: ${{ steps.close_issue.outputs.data }}
+          close-issue-message: ${{ steps.read_yaml.outputs.close-issue }}
           # Comment on the staled PRs
-          stale-pr-message: ${{ steps.stale_pr.outputs.data }}
+          stale-pr-message: ${{ steps.read_yaml.outputs.stale-pr }}
           # Comment on the staled PRs while closed
-          close-pr-message: ${{ steps.close_pr.outputs.data }}
+          close-pr-message: ${{ steps.read_yaml.outputs.close-pr }}
           # Label to apply on staled issues
           stale-issue-label: 'stale'
           # Label to apply on closed issues

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: read_yaml
-        uses: conda/actions/read-yaml@v22.2.0
+        uses: conda/actions/read-yaml@v22.2.1
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
           scopes: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       - id: read_yaml
         uses: conda/actions/read-yaml@v22.2.0
         with:
-          path: .github/messages.yml
+          path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
           scopes: |
             stale-issue: stale-issue
             close-issue: close-issue
@@ -32,7 +32,7 @@ jobs:
           # Idle number of days before closing stale issues/PRs (default: 7)
           days-before-issue-close: 90
           # Idle number of days before marking PRs stale (default: 60)
-          days-before-pr-stale: 360
+          days-before-pr-stale: 365
           # Idle number of days before closing stale PRs (default: 7)
           days-before-pr-close: 30
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   stale:
+    if: '!github.event.repository.fork'
     runs-on: ubuntu-latest
     steps:
       - id: read_yaml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,95 @@
+name: Stale
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "dryrun: Preview stale issues/prs without marking them (true|false)"
+        required: true
+        default: "true"
+  schedule:
+    - cron: 0 4 * * *
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: stale_issue
+        uses: KJ002/read-yaml@1.5
+        with:
+          file: .github/messages.yml
+          key-path: stale-issue
+      - id: close_issue
+        uses: KJ002/read-yaml@1.5
+        with:
+          file: .github/messages.yml
+          key-path: close-issue
+      - id: stale_pr
+        uses: KJ002/read-yaml@1.5
+        with:
+          file: .github/messages.yml
+          key-path: stale-pr
+      - id: close_pr
+        uses: KJ002/read-yaml@1.5
+        with:
+          file: .github/messages.yml
+          key-path: close-pr
+      - uses: actions/stale@v4
+        id: stale
+        with:
+          # Idle number of days before marking issues stale (default: 60)
+          days-before-issue-stale: 365
+          # Idle number of days before closing stale issues/PRs (default: 7)
+          days-before-issue-close: 90
+          # Idle number of days before marking PRs stale (default: 60)
+          days-before-pr-stale: 360
+          # Idle number of days before closing stale PRs (default: 7)
+          days-before-pr-close: 30
+
+          # Comment on the staled issues
+          stale-issue-message: ${{ steps.stale_issue.outputs.data }}
+          # Comment on the staled issues while closed
+          close-issue-message: ${{ steps.close_issue.outputs.data }}
+          # Comment on the staled PRs
+          stale-pr-message: ${{ steps.stale_pr.outputs.data }}
+          # Comment on the staled PRs while closed
+          close-pr-message: ${{ steps.close_pr.outputs.data }}
+          # Label to apply on staled issues
+          stale-issue-label: 'stale'
+          # Label to apply on closed issues
+          close-issue-label: 'stale::closed'
+          # Label to apply on staled PRs
+          stale-pr-label: 'stale'
+          # Label to apply on closed PRs
+          close-pr-label: 'stale::closed'
+
+          # Issues with these labels will never be considered stale
+          exempt-issue-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
+          # Issues with these labels will never be considered stale
+          exempt-pr-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
+
+          # Max number of operations per run
+          operations-per-run: ${{ secrets.STALE_OPERATIONS_PER_RUN || 100 }}
+          # Remove stale label from issues/PRs on updates/comments
+          remove-stale-when-updated: true
+
+          # Add specified labels to issues/PRs when they become unstale
+          labels-to-add-when-unstale: 'stale::recovered'
+          labels-to-remove-when-unstale: 'stale,stale::closed'
+
+          # Dry-run (default: false)
+          debug-only: ${{ github.event.inputs.dryrun || false }}
+          # Order to get issues/PRs (default: false)
+          ascending: true
+          # Delete branch after closing a stale PR (default: false)
+          delete-branch: false
+
+          # Exempt all issues/PRs with milestones from stale
+          exempt-all-milestones: true
+
+          # Assignees on issues/PRs exempted from stale
+          exempt-assignees: mingwandroid
+
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/boards.yml
       - .github/workflows/issues.yml
       - .github/workflows/labels.yml
+      - .github/workflows/stale.yml
 
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch


### PR DESCRIPTION
Moving stale workflow defined in conda/conda & conda/conda-build here to standardize across all repos. Since individual repos will have different stale/close messages I have moved those individual messages into a separate yaml file (`messages.yml`) so it can be customized per repo.

Opted to enable this stale workflow for **all** conda repos (except the two conda-build test repos), not just the selection identified previously for board automations.