### PR TITLE
Add `stale::recovered` issues to triage board

### DIFF
--- a/.github/workflows/boards.yml
+++ b/.github/workflows/boards.yml
@@ -19,12 +19,20 @@ env:
 jobs:
   # new -> Triaging[New]
   to_triaging:
-    # if new issue and not [backlog] or [sprint]
+    # if new issue (or old issue marked as [stale::recovered]) and not [backlog] or [sprint]
     if: >-
       !github.event.repository.fork
-      && github.event.sender.login != 'conda-bot'
       && github.event_name == 'issues'
-      && github.event.action == 'opened'
+      && (
+        (
+          github.event.sender.login != 'conda-bot'
+          && github.event.action == 'opened'
+        )
+        || (
+          github.event.action == 'labeled'
+          && github.event.label.name == 'stale::recovered'
+        )
+      )
       && !contains(github.event.issue.labels.*.name, 'backlog')
       && !contains(github.event.issue.labels.*.name, 'sprint')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, when an issue is marked as https://github.com/conda/infra/labels/stale%3A%3Arecovered we have to manually notice this and then add it to the triaging board. This change intends to automate this with the following assumptions:

1. If an issue exists on the triaging, backlog, or sprint board and is labeled as https://github.com/conda/infra/labels/stale%3A%3Arecovered it should simply stay there
2. All other issues that are labeled with https://github.com/conda/infra/labels/stale%3A%3Arecovered should be added to the triaging board's **New** column so the triaging engineer can see it and address the issue