### PR TITLE
[WIP] Include New "Stale" Workflow for Support Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,9 +23,9 @@ jobs:
         id: stale
         with:
           # Idle number of days before marking issues stale (default: 60)
-          days-before-issue-stale: 365
+          days-before-issue-stale: ${{ (github.event.label.name == 'type::support') && 21 || 365 }}
           # Idle number of days before closing stale issues/PRs (default: 7)
-          days-before-issue-close: 90
+          days-before-issue-close: ${{ (github.event.label.name == 'type::support') && 7 || 90 }}
           # Idle number of days before marking PRs stale (default: 60)
           days-before-pr-stale: 365
           # Idle number of days before closing stale PRs (default: 7)


### PR DESCRIPTION
Depends-on https://github.com/conda/infra/pull/508

We need a new GitHub Actions workflow for closing out stale issues which have the `type::support` label on them.