### PR TITLE
Include fallback stale/close/lock message if none defined

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -36,7 +36,7 @@ jobs:
           # Labels to add before locking an issue, value must be a comma separated list of labels or ''
           issue-lock-labels: 'locked'
           # Comment to post before locking an issue
-          issue-lock-comment: ${{ steps.read_yaml.outputs.lock_issue }}
+          issue-lock-comment: ${{ steps.read_yaml.outputs.lock_issue || 'undefined' }}
           # Reason for locking an issue, value must be one of resolved, off-topic, too heated, spam or ''
           issue-lock-reason: 'resolved'
 
@@ -49,7 +49,7 @@ jobs:
           # Labels to add before locking a pull request, value must be a comma separated list of labels or ''
           pr-lock-labels: 'locked'
           # Comment to post before locking a pull request
-          pr-lock-comment: ${{ steps.read_yaml.outputs.lock_pr }}
+          pr-lock-comment: ${{ steps.read_yaml.outputs.lock_pr || 'undefined' }}
           # Reason for locking a pull request, value must be one of resolved, off-topic, too heated, spam or ''
           pr-lock-reason: 'resolved'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,13 +37,13 @@ jobs:
           days-before-pr-close: 30
 
           # Comment on the staled issues
-          stale-issue-message: ${{ steps.read_yaml.outputs.stale_issue }}
+          stale-issue-message: ${{ steps.read_yaml.outputs.stale_issue || 'undefined' }}
           # Comment on the staled issues while closed
-          close-issue-message: ${{ steps.read_yaml.outputs.close_issue }}
+          close-issue-message: ${{ steps.read_yaml.outputs.close_issue || 'undefined' }}
           # Comment on the staled PRs
-          stale-pr-message: ${{ steps.read_yaml.outputs.stale_pr }}
+          stale-pr-message: ${{ steps.read_yaml.outputs.stale_pr || 'undefined' }}
           # Comment on the staled PRs while closed
-          close-pr-message: ${{ steps.read_yaml.outputs.close_pr }}
+          close-pr-message: ${{ steps.read_yaml.outputs.close_pr || 'undefined' }}
           # Label to apply on staled issues
           stale-issue-label: 'stale'
           # Label to apply on closed issues


### PR DESCRIPTION
If none of our stale/close/lock messages get set we provide a fallback value to make it clear that the value is missing.