### PR TITLE
Use static output from `read-yaml`

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -22,9 +22,6 @@ jobs:
         uses: conda/actions/read-yaml@v22.2.1
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
-          scopes: |
-            lock_issue: lock-issue
-            lock_pr: lock-pr
       - uses: dessant/lock-threads@v2
         with:
           # Number of days of inactivity before a closed issue is locked
@@ -36,7 +33,7 @@ jobs:
           # Labels to add before locking an issue, value must be a comma separated list of labels or ''
           issue-lock-labels: 'locked'
           # Comment to post before locking an issue
-          issue-lock-comment: ${{ steps.read_yaml.outputs.lock_issue || 'undefined' }}
+          issue-lock-comment: ${{ fromJSON(steps.read_yaml.outputs.value)["lock-issue"] }}
           # Reason for locking an issue, value must be one of resolved, off-topic, too heated, spam or ''
           issue-lock-reason: 'resolved'
 
@@ -49,7 +46,7 @@ jobs:
           # Labels to add before locking a pull request, value must be a comma separated list of labels or ''
           pr-lock-labels: 'locked'
           # Comment to post before locking a pull request
-          pr-lock-comment: ${{ steps.read_yaml.outputs.lock_pr || 'undefined' }}
+          pr-lock-comment: ${{ fromJSON(steps.read_yaml.outputs.value)["lock-pr"] }}
           # Reason for locking a pull request, value must be one of resolved, off-topic, too heated, spam or ''
           pr-lock-reason: 'resolved'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,11 +19,6 @@ jobs:
         uses: conda/actions/read-yaml@v22.2.1
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
-          scopes: |
-            stale_issue: stale-issue
-            close_issue: close-issue
-            stale_pr: stale-pr
-            close_pr: close-pr
       - uses: actions/stale@v4
         id: stale
         with:
@@ -37,13 +32,13 @@ jobs:
           days-before-pr-close: 30
 
           # Comment on the staled issues
-          stale-issue-message: ${{ steps.read_yaml.outputs.stale_issue || 'undefined' }}
+          stale-issue-message: ${{ fromJSON(steps.read_yaml.outputs.value)["stale-issue"] }}
           # Comment on the staled issues while closed
-          close-issue-message: ${{ steps.read_yaml.outputs.close_issue || 'undefined' }}
+          close-issue-message: ${{ fromJSON(steps.read_yaml.outputs.value)["close-issue"] }}
           # Comment on the staled PRs
-          stale-pr-message: ${{ steps.read_yaml.outputs.stale_pr || 'undefined' }}
+          stale-pr-message: ${{ fromJSON(steps.read_yaml.outputs.value)["stale-pr"] }}
           # Comment on the staled PRs while closed
-          close-pr-message: ${{ steps.read_yaml.outputs.close_pr || 'undefined' }}
+          close-pr-message: ${{ fromJSON(steps.read_yaml.outputs.value)["close-pr"] }}
           # Label to apply on staled issues
           stale-issue-label: 'stale'
           # Label to apply on closed issues


### PR DESCRIPTION
Given the realization that composite GHA does not support dynamic outputs `read-yaml` had to be refactored and this change adjusts for those changes.