### PR TITLE
Update lock schedule

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,7 +11,9 @@ on:
     #     default: "true"
 
   schedule:
-    - cron: 0 6 * * *
+    # on the hour, every 24 hours
+    # https://crontab.guru/#0_5_*_*_*
+    - cron: 0 5 * * *
 
 permissions:
   issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,8 @@ on:
         default: "true"
 
   schedule:
+    # on the hour, every 24 hours
+    # https://crontab.guru/#0_4_*_*_*
     - cron: 0 4 * * *
 
 jobs:


### PR DESCRIPTION
Attempting to avoid GH's secondary rate limit. See recent failures: https://github.com/conda/conda/actions/workflows/lock.yml