### PR TITLE
Implement New Stale/Closed Timeline for `type::support` Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,9 @@ jobs:
   stale:
     if: '!github.event.repository.fork'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        only-issue-labels: ['type::support', null]
     steps:
       - id: read_yaml
         uses: conda/actions/read-yaml@v22.2.1
@@ -26,9 +29,9 @@ jobs:
         id: stale
         with:
           # Idle number of days before marking issues stale (default: 60)
-          days-before-issue-stale: 365
+          days-before-issue-stale: ${{ matrix.only-issue-labels == "type::support" && 21 || 365 }}
           # Idle number of days before closing stale issues/PRs (default: 7)
-          days-before-issue-close: 90
+          days-before-issue-close: ${{ matrix.only-issue-labels == "type::support" && 7 || 90 }}
           # Idle number of days before marking PRs stale (default: 60)
           days-before-pr-stale: 365
           # Idle number of days before closing stale PRs (default: 7)
@@ -55,6 +58,8 @@ jobs:
           exempt-issue-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
           # Issues with these labels will never be considered stale
           exempt-pr-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
+          # The issue labels that have a different stale/close timeline from the rest
+          only-issue-labels: ${{ matrix.only-issue-labels }}
 
           # Max number of operations per run
           operations-per-run: ${{ secrets.STALE_OPERATIONS_PER_RUN || 100 }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # The issues labeled "support" have a more aggressive stale/close timeline from the rest
         only-issue-labels: ['type::support', null]
     steps:
       - id: read_yaml
@@ -58,7 +59,7 @@ jobs:
           exempt-issue-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
           # Issues with these labels will never be considered stale
           exempt-pr-labels: 'stale::recovered,good-first-issue,help-wanted,severity::1,source::partner,¡important!,¡security!,type::tech-debt,Epic,priority-high'
-          # The issue labels that have a different stale/close timeline from the rest
+          # Only issues with these labels are checked whether they are stale
           only-issue-labels: ${{ matrix.only-issue-labels }}
 
           # Max number of operations per run


### PR DESCRIPTION
Updating the GitHub Actions `stale.yml` workflow for issues which have the `type::support` label on them.