### PR TITLE
Revert "Add `[type::tests]` label"

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -116,11 +116,7 @@
 - name: type::task
   description: indicates a change that doesn't pertain to the code itself, e.g. updating CI/CQ, rebuilding package
   color: "fff2cc"
-  aliases: ["Type: Maintenance", "type:task"]
-- name: type::test
-  description: issues with or request for new tests
-  color: "fff2cc"
-  aliases: [type-new_test]
+  aliases: [type-new_test, "Type: Maintenance", "type:task"]
 
 # Severity
 - name: severity::1


### PR DESCRIPTION
Reverts conda/infra#532

This didn't add a type::tests label and I would have liked to respond to this before being merged.