### PR TITLE
Adding issue/PR automation to add to the beta project

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -20,6 +20,9 @@ group:
       # triage, backlog, & sprint board logic
       - source: .github/workflows/boards.yml
         dest: .github/workflows/boards.yml
+      # beta project
+      - source: .github/workflows/project.yml
+        dest: .github/workflows/project.yml
       # issue logic
       - source: .github/workflows/issues.yml
         dest: .github/workflows/issues.yml

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,18 @@
+name: Add to Project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.0.3
+        with:
+          project-url: https://github.com/orgs/conda/projects/2
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,10 +9,13 @@ on:
       - .github/sync.yml  # trigger sync if sync config is modified
       - .github/workflows/sync.yml  # trigger sync if sync workflow is modified
       - .github/workflows/boards.yml
+      - .github/workflows/project.yml
       - .github/workflows/issues.yml
       - .github/workflows/labels.yml
       - .github/workflows/stale.yml
       - .github/workflows/lock.yml
+      - .github/workflows/cla.yml
+      - .github/ISSUE_TEMPLATE/epic.yml
 
   # NOTE: github.event is workflow_dispatch payload:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch


### PR DESCRIPTION
Working to replace triaging/backlog/sprint boards with one combined beta project.

This action simply automates adding all new issues and PRs to the beta project. Moving issues across the various views will be defined by the presence of labels.

Ref https://github.com/conda/infra/issues/515 https://github.com/conda/infra/issues/546

Stumbled across this action via [GitHub Roadmap](https://github.com/github/roadmap/issues/286) and https://github.com/itchysats/itchysats/pull/1383.