### PR TITLE
Add issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_bug.yml
+++ b/.github/ISSUE_TEMPLATE/0_bug.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Create a bug report.
+labels:
+  - type::bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Processing bug reports is time consuming so please fill out the following form as completely as possible. **The more complete you are the more likely we can provide a speedier response.**
+
+        > ⚠️ Reports that are incomplete or missing information will simply be closed.
+
+        Since there are already a lot of open issues, please take a moment to search existing ones to see if your bug has already been reported. If you find something related, please upvote that report and provide additional details as necessary.
+
+        > 💐 Thanks for helping to make Conda better! We would be unable to do the things we do without our community!
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a descriptive title
+          required: true
+        - label: I searched open reports and couldn't find a duplicate
+          required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What should have happened instead? Please provide as many details as possible. The more information provided the more likely we are able to replicate your problem and offer a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: info
+    attributes:
+      label: Conda Info
+      description: |
+        Let's collect some basic information about your conda install.
+
+        Please run the following command from your command line and paste the output below.
+
+        ```bash
+        conda info
+        ```
+      render: shell
+  - type: textarea
+    id: config
+    attributes:
+      label: Conda Config
+      description: |
+        Let's collect any customizations you may have for your conda install.
+
+        Please run the following command from your command line and paste the output below.
+
+        ```bash
+        conda config --show-sources
+        ```
+      render: shell
+  - type: textarea
+    id: list
+    attributes:
+      label: Conda list
+      description: |
+        The packages installed into your environment can offer clues as to the problem you are facing.
+
+        Please ensure you have activated the environment within which you are encountering this bug and run the following command from your command line and paste the output below.
+
+        ```bash
+        conda list --show-channel-urls
+        ```
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include any additional information (or screenshots) that you think would be valuable.

--- a/.github/ISSUE_TEMPLATE/1_feature.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Create a feature request.
+labels:
+  - type::feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Processing feature requests is time consuming so please fill out the following form as completely as possible. **The more complete you are the more likely we can provide a speedier response.**
+
+        > ⚠️ Requests that are incomplete or missing information will simply be closed.
+
+        Since there are already a lot of open requests, please take a moment to search existing ones to see if your idea has already been proposed. If you find something related, please upvote that request and provide additional details as necessary.
+
+        > 💐 Thanks for helping to make Conda better! We would be unable to do the things we do without our community!
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      description: Please confirm and check all the following options.
+      options:
+        - label: I added a descriptive title
+          required: true
+        - label: I searched open requests and couldn't find a duplicate
+          required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What is the idea?
+      description: Describe what the feature is and the desired state.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: Who would benefit from this feature? Why would this add value to them? What problem does this solve?
+  - type: textarea
+    id: what
+    attributes:
+      label: What should happen?
+      description: What should be the user experience with the feature? Describe from a user perpective what they would do and see.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include any additional information that you think would be valuable.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,7 @@
-name: Epic
-description: (for conda-core team only) A collection of smaller related tickets
-labels: [epic]
+name: "[private] Epic"
+description: "[for conda team only] A collection of related tickets."
+labels:
+  - epic
 body:
   - type: textarea
     attributes:
@@ -16,9 +17,6 @@ body:
       label: Linked Issues & PRs
       description: List all issues related to this epic.
       value: |
-        - #
-        - #
-        - #
-        ...
+        - [ ] #
     validations:
       required: true


### PR DESCRIPTION
Standardized bug and feature issue forms. Both forms are more or less repo agnostic so these should be appropriate for all conda and friends repos that we [sync out to](https://github.com/conda/infra/blob/1fe864483b60daf6f7ff66cb05e01eba4d235cbd/.github/sync.yml#L3-L18).

Resolves #558 

| Bug Report | Feature Request |
|---|---|
| ![](https://user-images.githubusercontent.com/4546435/175103086-40c212c6-efdf-48ab-9a1c-80cd942ddbd9.png) | ![](https://user-images.githubusercontent.com/4546435/175103052-7accf586-252b-4bdb-90a2-a4ef5cfc93e6.png) |
