### PR TITLE
Add future directive

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -16,6 +16,7 @@ In an effort to decrease the context switching/learning barrier between the diff
 | <a name="7"></a>7 | Use American English. | [`flake8-spellcheck`](https://github.com/MichaelAquilina/flake8-spellcheck) |
 | <a name="7.1"></a>7.1 | Use inclusive language. See these other great resources for details: <ul><li>[Google](https://developers.google.com/style/inclusive-documentation)</li><li>[HubSpot](https://blog.hubspot.com/marketing/inclusive-language)</li><li>[Apple](https://support.apple.com/guide/applestyleguide/intro-apdcb2a65d68/1.0/web/1.0)</li></ul> | |
 | <a name="7.2"></a>7.2 | Use descriptive variable names: <ul><li>no one-char variables</li><li>avoid abbreviations</li><li>avoid overloading builtins</li></ul> | [`flake8-variables-names`](https://github.com/best-doctor/flake8-variables-names) |
+| <a name="8"></a>8 | When indicating a change that requires a future version of Python (or dropping a currently-supported version), use the following format:<br>`# FUTURE: <minimum Python requirement>, <details>`<br>e.g.:<br>`# FUTURE: Python 3.9+, replace with ...` | |
 
 | Other Tooling |
 |---|


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Continuation of https://github.com/conda/infra/pull/568#discussion_r930169578.

> **[@jezdez said:](https://github.com/conda/infra/pull/568#discussion_r930169578)**
> I'm not sure about [`# FUTURE`], one thing that Python, Django etc uses are the [`.. versionadded` and `.. versionchanged` Sphinx directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded), which Sphinx' autodoc can read in docstrings and next to module level variables.
>
> Could you look into if there is a pattern that is Sphinx/autodoc compatible that would allow us to bubble up the "future" information in the docs as well? Like a `.. future: Python 3.9+, replace with ...` for docstrings and `#: .. future: Python 3.9+, replace with ...` for [module or class attribute documentation comments](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoproperty)?
>
> **[@kenodegard said:](https://github.com/conda/infra/pull/568#discussion_r930190393)**
I'm all for reusing existing standards, but I'm not sure we want this kind of info bubbled up into the docstrings. This seems too developer-focused, not something the end-user would care about (and could even be confused by).
>
> My intention with the formatting I chose was to mirror that of `# TODO` because it's something to do in the future. The goal was to make a syntax that made it an easy find/replace process.
> 
> This was originally inspired by trying to indicate future tech-debt work:
> 
> ```python
> # FUTURE: Python 3.8+, replace w/ functools.cache_property
> @property
> @functools.lru_cache(maxsize=None)
> def plugin_manager(self):
>     ...
> 
> # FUTURE: Python 3.9+, replace w/ functools.cache
> @functools.lru_cache(maxsize=None)
> def _get_cpu_info():
>     ...
> ```

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
