### PR TITLE
Rever needs to use the correct project name

### DIFF
--- a/.github/rever.xsh
+++ b/.github/rever.xsh
@@ -1,7 +1,7 @@
 $ACTIVITIES = ["authors", "changelog"]
 
 # Basic settings
-$PROJECT = $GITHUB_REPO = @($(basename $(git remote get-url origin)).split('.')[0])
+$PROJECT = $GITHUB_REPO = $(basename $(git remote get-url origin)).split('.')[0]
 $GITHUB_ORG = "conda"
 
 # Authors settings

--- a/.github/rever.xsh
+++ b/.github/rever.xsh
@@ -1,7 +1,7 @@
 $ACTIVITIES = ["authors", "changelog"]
 
 # Basic settings
-$PROJECT = $GITHUB_REPO = "conda"
+$PROJECT = $GITHUB_REPO = @($(basename $(git remote get-url origin)).split('.')[0])
 $GITHUB_ORG = "conda"
 
 # Authors settings


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

After merging #601 I realized the synced `rever.xsh` config had the project hardcoded as "conda", this changes this to properly extract the correct project name.

I've tested this by launching xonsh and sourcing rever.xsh:

```bash
$ xonsh .github/rever.xsh

$ xonsh
$ source .github/rever.xsh
$ $PROJECT
'infra'
```

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
