### PR TITLE
Adding a several new "documentation" tags

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -232,12 +232,15 @@
   aliases: [reproducibility]
 
 # Documentation
-- name: documentation::testing
-  description: related to writing tests
+- name: documentation::tutorials
+  description: related to tutorials (learning-oriented)
   color: "31A354"
-- name: documentation::developer
-  description: related to API and internal workings of project
+- name: documentation::how-tos
+  description: related to how-tos (task-oriented)
   color: "31A354"
-- name: documentation::user
-  description: related to documentation describing how the project is used
+- name: documentation::reference
+  description: related to the API and internals (information-oriented)
+  color: "31A354"
+- name: documentation::explanation
+  description: related to higher-level clarification (understanding-oriented)
   color: "31A354"

--- a/.github/global.yml
+++ b/.github/global.yml
@@ -234,13 +234,13 @@
 # Documentation
 - name: documentation::tutorials
   description: related to tutorials (learning-oriented)
-  color: "31A354"
+  color: "77b2dc"
 - name: documentation::how-tos
   description: related to how-tos (task-oriented)
-  color: "31A354"
+  color: "77b2dc"
 - name: documentation::reference
   description: related to the API and internals (information-oriented)
-  color: "31A354"
+  color: "77b2dc"
 - name: documentation::explanation
   description: related to higher-level clarification (understanding-oriented)
-  color: "31A354"
+  color: "77b2dc"

--- a/.github/global.yml
+++ b/.github/global.yml
@@ -230,3 +230,14 @@
   description: related to producing reproducible results
   color: "86C579"
   aliases: [reproducibility]
+
+# Documentation
+- name: documentation::testing
+  description: related to writing tests
+  color: "31A354"
+- name: documentation::developer
+  description: related to API and internal workings of project
+  color: "31A354"
+- name: documentation::user
+  description: related to documentation describing how the project is used
+  color: "31A354"


### PR DESCRIPTION
This pull request adds a new "documentation" section that we can use to better organize our "type::documentation" issues.