### PR TITLE
Remove planning and update type labels

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -41,23 +41,6 @@
     description: '[bot] PRs that update a dependency file'
     color: '#0366d6'
 
-# Planning
-  - name: planning::backlog
-    description: issue has been triaged but has not been earmarked for any upcoming release
-    color: '#a7f3d0'
-    aliases:
-      - 1_Backlog_Long_Term
-      - backlog
-  - name: planning::in-progress
-    description: issue is actively being worked on
-    color: '#a7f3d0'
-    aliases:
-      - sprint
-      - in-progress
-  - name: planning::refinement
-    description: issue is on the backlog but needs refinement or story points estimated
-    color: '#a7f3d0'
-
 # Sync
   - name: sync::anaconda
     description: sync internally with Anaconda, Inc. ticket tracker


### PR DESCRIPTION
### Description

Since planning is being done on GitHub Projects now, this PR removes the planning labels for backlog in-progress. Additionally, I moved epic and feature to the type category.

Type colors (all same): #fff2cc (light yellow) (except bug which stays #b60205)