### PR TITLE
Remove Discourse mentions from How we use Github

### DIFF
--- a/templates/HOW_WE_USE_GITHUB.md
+++ b/templates/HOW_WE_USE_GITHUB.md
@@ -250,7 +250,6 @@ support:
 Unfortunately, this issue is outside the scope of support we offer via GitHub or is not directly related to this project.
 Community support can be found elsewhere, though, and we encourage you to explore the following options:
 
-- [Conda discourse forum](https://conda.discourse.group/)
 - [Community chat channels](https://conda.org/community#chat)
 - [Stack Overflow posts tagged "conda"](https://stackoverflow.com/questions/tagged/conda)
 </pre>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Comes from [#infrastructure > https://conda.discourse.group is read-only](https://conda.zulipchat.com/#narrow/channel/487124-infrastructure/topic/https.3A.2F.2Fconda.2Ediscourse.2Egroup.20is.20read-only/with/544988504)

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
