### PR TITLE
Fix zizmor security issues in GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       workflows:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,11 @@ on:
       - created
   pull_request_target:
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   check:
     if: >-

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -15,21 +15,29 @@ on:
         description: The repository to push the update workflow to.
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   push:
     if: >-
       !github.event.repository.fork
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # repository: ${{ github.repository }}
           path: upstream
+          persist-credentials: false
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.inputs.org }}/${{ github.event.inputs.repo }}
           path: downstream
+          persist-credentials: false
 
       - name: Configure git user
         run: |
@@ -39,7 +47,10 @@ jobs:
       - name: (upstream) Remove repository from sync.yml
         # no-op if the repository is not in the sync.yml file
         continue-on-error: true
-        run: sed -i '\%${{ github.event.inputs.org }}/${{ github.event.inputs.repo }}$%d' upstream/sync/config.yml
+        env:
+          INPUT_ORG: ${{ github.event.inputs.org }}
+          INPUT_REPO: ${{ github.event.inputs.repo }}
+        run: sed -i "\%${INPUT_ORG}/${INPUT_REPO}$%d" upstream/sync/config.yml
 
       - name: (upstream) Commit changes
         # no-op if there are no updates

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   FEEDBACK_LBL: pending::feedback
   SUPPORT_LBL: pending::support

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,15 +15,23 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write
     env:
       GLOBAL: https://raw.githubusercontent.com/conda/infra/main/.github/global.yml
       LOCAL: .github/labels.yml
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - id: has_local
         uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add_to_project:
     if: '!github.event.repository.fork'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,6 +12,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   update:
     if: >-
@@ -29,6 +32,10 @@ jobs:
         )
       )
     runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - if: github.event_name == 'issue_comment'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
@@ -40,9 +47,11 @@ jobs:
 
       - if: github.event.comment.body == '@conda-bot render'
         name: Configure git origin
+        env:
+          PR_API_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          echo REPOSITORY=$(curl --silent ${{ github.event.issue.pull_request.url }} | jq --raw-output '.head.repo.full_name') >> $GITHUB_ENV
-          echo REF=$(curl --silent ${{ github.event.issue.pull_request.url }} | jq --raw-output '.head.ref') >> $GITHUB_ENV
+          echo REPOSITORY=$(curl --silent "$PR_API_URL" | jq --raw-output '.head.repo.full_name') >> $GITHUB_ENV
+          echo REF=$(curl --silent "$PR_API_URL" | jq --raw-output '.head.ref') >> $GITHUB_ENV
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,15 @@ repos:
     hooks:
       - id: codespell
         args: [--write-changes]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        exclude: ^\.github/workflows/stale\.yml$
   - repo: meta
     # see https://pre-commit.com/#meta-hooks
     hooks:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,23 @@
+# zizmor configuration file
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  dangerous-triggers:
+    ignore:
+      # cla.yml uses pull_request_target but the workflow only
+      # invokes conda/actions/check-cla which does not check out
+      # untrusted PR code. The trigger is required to react to
+      # new PRs for CLA verification.
+      - cla.yml
+
+      # project.yml uses pull_request_target but does not check
+      # out any code; it only adds PRs to a GitHub project board.
+      - project.yml
+
+  template-injection:
+    ignore:
+      # stale.yml uses join(steps.stale.outputs.*, ',') in a run
+      # block to echo stale action outputs. These outputs are not
+      # attacker-controlled (they come from the stale action itself).
+      # Low confidence finding.
+      - stale.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -14,6 +14,12 @@ rules:
       # out any code; it only adds PRs to a GitHub project board.
       - project.yml
 
+  artipacked:
+    ignore:
+      # update.yml needs persisted credentials for the subsequent
+      # git push --force-with-lease step (rendering bot commits).
+      - update.yml
+
   template-injection:
     ignore:
       # stale.yml uses join(steps.stale.outputs.*, ',') in a run


### PR DESCRIPTION
Audited all workflow files with zizmor v1.24.1 and fixed the findings. These are the upstream source workflows that get synced to other conda repos via `update.yml`, so fixing them here propagates the improvements everywhere.

## What changed

**Dependabot cooldowns** (`dependabot.yml`)
- Added 7-day cooldown to the github-actions ecosystem entry.

**Explicit permissions** (all workflows)
- Added `permissions:` blocks to `cla.yml`, `issues.yml`, `labels.yml`, `project.yml`, `update.yml`, `init.yml` following the principle of least privilege.
- Workflow-level `permissions: contents: read` with job-level escalation where write access is needed.

**Credential persistence** (`init.yml`, `labels.yml`)
- Added `persist-credentials: false` to `actions/checkout` steps that don't need git credentials after checkout.
- `update.yml` intentionally keeps credentials for the `git push --force-with-lease` step (suppressed in `zizmor.yml`).

**Template injection** (`init.yml`, `update.yml`)
- `init.yml`: Replaced `${{ github.event.inputs.org/repo }}` in `sed` command with env vars.
- `update.yml`: Replaced `${{ github.event.issue.pull_request.url }}` in `curl` commands with env var.

**Suppressions** (`zizmor.yml`)
- `cla.yml` and `project.yml` dangerous-triggers: `pull_request_target` is used safely (no code checkout).
- `stale.yml` template-injection: Low confidence, outputs are not attacker-controlled.
- `update.yml` artipacked: Credentials needed for bot push.

**Pre-commit hooks** (`.pre-commit-config.yaml`)
- Added `zizmor` (v1.24.1) and `actionlint` (v1.7.12) hooks.
- `actionlint` excludes `stale.yml` due to a known expression type mismatch.

## Audit result

```
zizmor v1.24.1: No findings to report. Good job! (4 ignored, 50 suppressed)
```

## Downstream impact

Once merged and synced, the corresponding suppressions in `conda/actions` PR #361 (`zizmor.yml`) can be removed since the source workflows will already be fixed.