### PR TITLE
Enable zizmor auditor persona

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,13 +6,16 @@ on:
       - created
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   check:
+    name: Check CLA
     if: >-
       !github.event.repository.fork
       && (
@@ -21,6 +24,10 @@ jobs:
         || github.event_name == 'pull_request_target'
       )
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: write  # Required to update labels and comments on pull requests.
+      statuses: write  # Required to publish the CLA commit status.
     steps:
       - name: Check CLA
         uses: conda/actions/check-cla@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -15,17 +15,22 @@ on:
         description: The repository to push the update workflow to.
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.org }}-${{ github.event.inputs.repo }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   push:
+    name: Push repository updates
     if: >-
       !github.event.repository.fork
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # Required to commit the upstream sync.yml removal.
+      pull-requests: write  # Required to open upstream and downstream initialization PRs.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -67,7 +72,8 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          echo "UPSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
+          UPSTREAM="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          echo "UPSTREAM=${UPSTREAM}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 
@@ -119,7 +125,8 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          echo "DOWNSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
+          DOWNSTREAM="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          echo "DOWNSTREAM=${DOWNSTREAM}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -6,9 +6,12 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  issues: write
 
 env:
   FEEDBACK_LBL: pending::feedback
@@ -19,12 +22,16 @@ jobs:
   # TODO: create conda-issue-sorting team and modify this to toggle label based on
   # whether a non-issue-sorting engineer commented
   pending_support:
+    name: Update pending support label
     # if [pending::feedback] and anyone responds
     if: >-
       !github.event.repository.fork
       && !github.event.issue.pull_request
       && contains(github.event.issue.labels.*.name, 'pending::feedback')
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write  # Required to remove and add issue triage labels.
     steps:
       # remove [pending::feedback]
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,16 +15,21 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   sync:
+    name: Sync labels
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: write
+      issues: write  # Required to create, update, and delete repository issue labels.
     env:
       GLOBAL: https://raw.githubusercontent.com/conda/infra/main/.github/global.yml
       LOCAL: .github/labels.yml

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,14 +8,21 @@ on:
   schedule:
     - cron: 0 6 * * *
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   lock:
+    name: Lock inactive threads
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
+    permissions:
+      issues: write  # Required to lock inactive issues.
+      pull-requests: write  # Required to lock inactive pull requests.
     steps:
       - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,11 +5,16 @@ on:
     types:
       - opened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   add_to_project:
+    name: Add pull request to project
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,14 +14,21 @@ on:
   schedule:
     - cron: 0 4 * * *
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale:
+    name: Mark stale threads
     if: '!github.event.repository.fork'
     runs-on: ubuntu-slim
+    permissions:
+      issues: write  # Required to mark and close stale issues.
+      pull-requests: write  # Required to mark and close stale pull requests.
     strategy:
       matrix:
         include:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,16 +8,21 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   update:
+    name: Update repository files
     runs-on: ubuntu-slim
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: write  # Required to commit synced template and workflow updates.
+      pull-requests: write  # Required to open the generated update pull request.
+      issues: write  # Required for generated update pull request metadata.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -47,7 +52,9 @@ jobs:
 
       - name: Create fork
         # no-op if the repository is already forked
-        run: echo "FORK=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
+        run: |
+          FORK="$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')"
+          echo "FORK=${FORK}" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,10 @@ repos:
       - id: codespell
         args: [--write-changes]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
+        args: [--persona=auditor, --fix=safe]
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -20,6 +20,28 @@ rules:
       # git push --force-with-lease step (rendering bot commits).
       - update.yml
 
+  secrets-outside-env:
+    ignore:
+      # These workflows use repository/org secrets for cross-repo bot
+      # automation. Requiring deployment environments would change the
+      # automation model and is intentionally tracked as a policy decision
+      # outside this audit-hardening pass.
+      - cla.yml
+      - init.yml
+      - issues.yml
+      - project.yml
+      - stale.yml
+      - update.yml
+
+  superfluous-actions:
+    ignore:
+      # These helper actions are pinned and currently provide workflow
+      # behavior that would need dedicated migration PRs before replacing
+      # them with inline GitHub CLI commands.
+      - init.yml
+      - issues.yml
+      - update.yml
+
   template-injection:
     ignore:
       # stale.yml uses join(steps.stale.outputs.*, ',') in a run


### PR DESCRIPTION
### Description

Follow-up to conda/infrastructure#1328 and the `conda/actions` auditor-persona work:

- conda/actions#361 enabled stricter `zizmor` coverage downstream.
- conda/actions#454 keeps synced `lock.yml` unchanged downstream and suppresses the remaining synced-workflow auditor findings locally.
- conda/actions#451 tracks removing those downstream suppressions once the upstream synced workflows are fixed.

This bumps the `zizmor` pre-commit hook to v1.25.2 and enables the auditor persona with safe fixes, matching the stricter configuration now used in `conda/actions`.

What changed:

- Added workflow-level concurrency limits and explicit job names for the synced workflows.
- Moved broad workflow-level write permissions to job-level permissions where possible.
- Added inline comments documenting write permissions.
- Added upstream-owned `zizmor.yml` ignores for accepted `secrets-outside-env` and `superfluous-actions` findings.
- Fixed `actionlint`/ShellCheck quoting issues in `init.yml` and `update.yml` that surfaced under the full pre-commit run.

Audit result:

```
zizmor --persona=auditor .github/workflows
No findings to report. Good job! (22 ignored)
```

Verification:

```
pre-commit run --all-files
zizmor --persona=auditor .github/workflows
```
