### PR TITLE
Fix no such remote fork error

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -67,7 +67,7 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          echo UPSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}') >> $GITHUB_ENV
+          echo "UPSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 
@@ -119,7 +119,7 @@ jobs:
           echo ::group::Fork debugging
           gh repo fork --clone=false --default-branch-only
           echo ::endgroup::
-          echo DOWNSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}') >> $GITHUB_ENV
+          echo "DOWNSTREAM=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create fork
         # no-op if the repository is already forked
-        run: echo FORK=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}') >> $GITHUB_ENV
+        run: echo "FORK=$(gh repo fork --clone=false --default-branch-only 2>&1 | awk '{print $1}' | sed 's|^https://github.com/||')" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
When trying to initialize using workflow dispatch the conda-rattler-solver repository, I got the following error:

```
Determining the base and head repositories
  Checking if 'https://github.com/conda-bot/conda-rattler-solver' is a fork of 'conda/conda-rattler-solver'
  Error: Not Found - https://docs.github.com/rest
Restore git configuration
  /usr/bin/git remote rm fork
  error: No such remote: 'fork'
  Error: The process '/usr/bin/git' failed with exit code 2
```

When I reran it, it passed because the conda-bot fork was already created.

This PR fixes this by stripping out the `http://github.com` from the fork so that it becomes `conda-bot/conda-rattler-solver` which is the syntax that the gh CLI needs.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
