### PR TITLE
Fix Jinja2 syntax by escaping with quotes

### DIFF
--- a/templates/config.yml
+++ b/templates/config.yml
@@ -50,10 +50,10 @@ conda/infrastructure:
   #   with:
   #     canary_channel: https://anaconda.org/conda-canary
   #     # CalVer placeholders
-  #     placeholder: YY.M.PATCH
-  #     placeholder_x: YY.M.x
+  #     placeholder: YY.MM.MICRO
+  #     placeholder_x: YY.MM.x
   #     # SemVer placeholders
-  #     placeholder: MAJOR.MINOR.MINOR
+  #     placeholder: MAJOR.MINOR.PATCH
   #     placeholder_x: MAJOR.MINOR.x
   # - src: templates/releases/rever.xsh
   #   dst: rever.xsh

--- a/templates/releases/RELEASE_ON_DEMAND.md
+++ b/templates/releases/RELEASE_ON_DEMAND.md
@@ -201,4 +201,4 @@ For conda-forge, the `regro-cf-autotick-bot` will usually open a PR automaticall
 
 ## 7. Announce the release.
 
-Post the release announcement on the Zulip thread in [#releases][zulip].
+Post the release announcement on the Zulip thread in [[ '[#releases][zulip]' ]].


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR fixes a templating error seen during this PR run: https://github.com/conda/conda-self/pull/144. 

```
[#releases][zulip]
 ^^
 comment opener — but no closing #]
 ```

The markdown results in a parse error. The fix wraps the markdown in a Jinja2 string literal inside a variable expression.

I also noticed that the placeholders for CalVer and SemVer weren't quite right, so I updated them.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
