### PR TITLE
Add canary workflow template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
         # exclude files that contain jinja templating directives
         exclude: |
           (?x)^(
-            templates/issues/bug.yml
+            templates/issues/bug.yml|
+            templates/workflows/build.yml
           )
       # catch git merge/rebase problems
       - id: check-merge-conflict
@@ -47,7 +48,8 @@ repos:
         # exclude files that contain jinja templating directives
         exclude: |
           (?x)^(
-            templates/issues/bug.yml
+            templates/issues/bug.yml|
+            templates/workflows/build.yml
           )
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.3

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -21,7 +21,7 @@ conda/infrastructure:
   #   dst: .github/workflows/build.yml
   # For noarch packages, add:
   #   with:
-  #     subdir: noarch
+  #     noarch: true
   # For conda itself (isolated activation required), add:
   #   with:
   #     conda_build_isolated_activation: true

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -51,6 +51,13 @@ conda/infrastructure:
   # - src: templates/dependabot/github-actions-full.yml
   #   dst: .github/dependabot.yml
 
+  # [optional] canary build workflow
+  # - src: templates/workflows/build.yml
+  #   dst: .github/workflows/build.yml
+  # For noarch packages, add:
+  #   with:
+  #     subdir: noarch
+
   # [optional] rever release files
   # Select one of the following:
   # conda and conda-build release file or

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -22,9 +22,9 @@ conda/infrastructure:
   # For noarch packages, add:
   #   with:
   #     noarch: true
-  # For conda itself (isolated activation required), add:
+  # For repos whose test workflow is not named "Tests", add:
   #   with:
-  #     conda_build_isolated_activation: true
+  #     tests_workflow: Test
 
   # [optional] general processes for the conda org
   - src: templates/HOW_WE_USE_GITHUB.md

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -22,6 +22,9 @@ conda/infrastructure:
   # For noarch packages, add:
   #   with:
   #     subdir: noarch
+  # For conda itself (isolated activation required), add:
+  #   with:
+  #     conda_build_isolated_activation: true
 
   # [optional] general processes for the conda org
   - src: templates/HOW_WE_USE_GITHUB.md

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -16,6 +16,13 @@ conda/infrastructure:
   - .github/workflows/stale.yml
   - .github/workflows/lock.yml
 
+  # [optional] canary build workflow
+  # - src: templates/workflows/build.yml
+  #   dst: .github/workflows/build.yml
+  # For noarch packages, add:
+  #   with:
+  #     subdir: noarch
+
   # [optional] general processes for the conda org
   - src: templates/HOW_WE_USE_GITHUB.md
     dst: HOW_WE_USE_GITHUB.md
@@ -50,13 +57,6 @@ conda/infrastructure:
   #   dst: .github/dependabot.yml
   # - src: templates/dependabot/github-actions-full.yml
   #   dst: .github/dependabot.yml
-
-  # [optional] canary build workflow
-  # - src: templates/workflows/build.yml
-  #   dst: .github/workflows/build.yml
-  # For noarch packages, add:
-  #   with:
-  #     subdir: noarch
 
   # [optional] rever release files
   # Select one of the following:

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -1,0 +1,206 @@
+# edit this in [[ source.html_url ]]
+
+name: Canary Builds
+
+on:
+  # Build canaries from PRs labeled build::review.
+  pull_request:
+    types:
+      - labeled
+
+  # Build canaries immediately on push to release branches (*.x).
+  push:
+    branches:
+      - '[0-9].*.x'  # e.g., 4.14.x
+      - '[0-9][0-9].*.x'  # e.g., 23.3.x
+
+  # Build canaries after a successful Tests run on main or feature/* branches.
+  workflow_run:
+    workflows:
+      - Tests
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  remove-build-label:
+    # Remove build::review after it runs so the label can be applied again.
+    if: >-
+      !github.event.repository.fork
+      && github.event.label.name == 'build::review'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Remove build label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          github-token: ${{ secrets.CANARY_ACTION_TOKEN }}
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            })
+            const buildLabel = '${{ github.event.label.name }}'
+            const labels = pullRequest.labels.map(label => label.name)
+            const hasBuildLabel = labels.includes(buildLabel)
+
+            if (hasBuildLabel) {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  name: buildLabel,
+                })
+            }
+
+  build:
+    # PR label build::review, push to *.x release branches, or successful Tests on main/feature/*.
+    if: >-
+      !github.event.repository.fork
+      && (
+        (
+          github.event_name == 'pull_request'
+          && github.event.label.name == 'build::review'
+        ) || (
+          github.event_name == 'push'
+          && endsWith(github.ref_name, '.x')
+        ) || (
+          github.event_name == 'workflow_run'
+          && github.event.workflow_run.event != 'pull_request'
+          && github.event.workflow_run.conclusion == 'success'
+          && (
+            github.event.workflow_run.head_branch == 'main'
+            || startsWith(github.event.workflow_run.head_branch, 'feature/')
+          )
+        )
+      )
+    env:
+      # Prefer workflow_run head; fallback to push/PR ref.
+      REF_NAME: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+      REF: ${{ github.event.workflow_run.head_sha || github.sha }}
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            subdir: [[subdir | default('linux-64')]]
+          - runs-on: ubuntu-24.04-arm
+            subdir: [[subdir | default('linux-aarch64')]]
+          - runs-on: macos-latest
+            subdir: [[subdir | default('osx-arm64')]]
+          - runs-on: windows-latest
+            subdir: [[subdir | default('win-64')]]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      # Clean checkout of specific git ref needed for package metadata version
+      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.REF }}
+          clean: true
+          fetch-depth: 0
+
+      # Explicitly use Python 3.11 since each of the OSes has a different default Python
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Detect Label
+        shell: python
+        run: |
+          import re
+          from pathlib import Path
+          from os import environ
+          from subprocess import check_output
+
+          # unless otherwise specified, commits are uploaded to the dev label
+          # e.g., `main` branch commits
+          envs = {"ANACONDA_ORG_LABEL": "dev"}
+
+          if "${{ github.event_name }}" == "pull_request":
+              # e.g., conda/conda/pr/123 -> conda-conda-pr-123
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/pr/${{ github.event.number }}"
+          elif "${{ env.REF_NAME }}".startswith("feature/"):
+              # e.g., conda/conda/feature/my-feature -> conda-conda-feature-my-feature
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.repository }}/${{ env.REF_NAME }}"
+          elif re.match(r"\d+(\.\d+)+\.x", "${{ env.REF_NAME }}"):
+              # e.g., conda/conda/rc/26.5.x -> conda-conda-rc-26.5.x
+              envs["ANACONDA_ORG_LABEL"] = f"${{ github.repository }}/rc/${{ env.REF_NAME }}"
+
+              # if no releases have occurred on this branch yet then `git describe --tag`
+              # will misleadingly produce a version number relative to the last release
+              # and not relative to the current release branch, if this is the case we need
+              # to override the version with a derivative of the branch name
+
+              # override the version if `git describe --tag` does not start with the branch version
+              last_release = check_output(["git", "describe", "--tag"], text=True).strip()
+              prefix = "${{ env.REF_NAME }}"[:-1]  # without x suffix
+              if not last_release.startswith(prefix):
+                  envs["VERSION_OVERRIDE"] = f"{prefix}0"
+
+          # workaround for anaconda.org's 404 error when trying to install from a slash label
+          envs["ANACONDA_ORG_LABEL"] = envs["ANACONDA_ORG_LABEL"].replace("/", "-")
+
+          Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
+
+      - name: Create & Upload
+        uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
+        env:
+          # Run conda-build in isolated activation to properly package conda
+          _CONDA_BUILD_ISOLATED_ACTIVATION: 1
+        with:
+          package-name: ${{ github.event.repository.name }}
+          subdir: ${{ matrix.subdir }}
+          anaconda-org-channel: conda-canary
+          anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
+          # Only comment on PRs
+          comment-headline: Review build status
+          comment-token: ${{ github.event_name == 'pull_request' && secrets.CANARY_ACTION_TOKEN || '' }}
+
+  report-canary-failure:
+    needs: [build]
+    # Only main and release (*.x) branches: feature/* canaries can fail without opening issues.
+    if: >-
+      always()
+      && !github.event.repository.fork
+      && needs.build.result == 'failure'
+      && (
+        (
+          github.event_name == 'workflow_run'
+          && !startsWith(github.event.workflow_run.head_branch, 'feature/')
+        ) || (
+          github.event_name == 'push'
+          && endsWith(github.ref_name, '.x')
+        )
+      )
+    runs-on: ubuntu-slim
+    steps:
+      - name: Report canary failure
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_REPORT_TEST_FAILURE }}
+          BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+        run: |
+          TITLE="${{ github.workflow }} failed \`${BRANCH}\`"
+          BODY="The ${{ github.workflow }} workflow failed on ${BRANCH} at $(date -u '+%Y-%m-%d %H:%M') UTC
+
+          Full run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "\"${TITLE}\" in:title label:source::auto sort:created-desc" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label "¡blocking!,type::bug,type::testing,source::auto"
+          fi

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -82,14 +82,19 @@ jobs:
     strategy:
       matrix:
         include:
+        [%- if noarch is defined %]
           - runs-on: ubuntu-latest
-            subdir: [[subdir | default('linux-64')]]
+            subdir: noarch
+        [%- else %]
+          - runs-on: ubuntu-latest
+            subdir: linux-64
           - runs-on: ubuntu-24.04-arm
-            subdir: [[subdir | default('linux-aarch64')]]
+            subdir: linux-aarch64
           - runs-on: macos-latest
-            subdir: [[subdir | default('osx-arm64')]]
+            subdir: osx-arm64
           - runs-on: windows-latest
-            subdir: [[subdir | default('win-64')]]
+            subdir: win-64
+        [%- endif %]
     runs-on: ${{ matrix.runs-on }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -14,10 +14,10 @@ on:
       - '[0-9].*.x'  # e.g., 4.14.x
       - '[0-9][0-9].*.x'  # e.g., 23.3.x
 
-  # Build canaries after a successful Tests run on main or feature/* branches.
+  # Build canaries after a successful test workflow run on main or feature/* branches.
   workflow_run:
     workflows:
-      - Tests
+      - [[ tests_workflow | default('Tests') ]]
     types:
       - completed
 
@@ -55,7 +55,7 @@ jobs:
             }
 
   build:
-    # PR label build::review, push to *.x release branches, or successful Tests on main/feature/*.
+    # PR label build::review, push to *.x release branches, or successful test workflow on main/feature/*.
     if: >-
       !github.event.repository.fork
       && (
@@ -152,10 +152,8 @@ jobs:
 
       - name: Create & Upload
         uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
-        [%- if conda_build_isolated_activation is defined and conda_build_isolated_activation %]
         env:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
-        [%- endif %]
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Create & Upload
         uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
-        [%- if conda_build_isolated_activation is defined %]
+        [%- if conda_build_isolated_activation is defined and conda_build_isolated_activation %]
         env:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
         [%- endif %]

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         include:
-        [%- if noarch is defined %]
+        [%- if noarch is defined and noarch %]
           - runs-on: ubuntu-latest
             subdir: noarch
         [%- else %]

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -93,7 +93,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version
-      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      # which needs env vars GIT_DESCRIBE_TAG, GIT_DESCRIBE_NUMBER, GIT_DESCRIBE_HASH,
+      # and optional VERSION_OVERRIDE:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.REF }}
@@ -146,9 +147,10 @@ jobs:
 
       - name: Create & Upload
         uses: conda/actions/canary-release@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
+        [%- if conda_build_isolated_activation is defined %]
         env:
-          # Run conda-build in isolated activation to properly package conda
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
+        [%- endif %]
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Helps close #1352 by adding a canary workflow template modeled off the one in conda. It includes jinja2 templating:
1. So that it can also be used with noarch packages like conda-libmamba-solver
2. conda can set `_CONDA_BUILD_ISOLATED_ACTIVATION: 1`

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
