### PR TITLE
Dependabot extras & run dependabot on workflow templates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+  - package-ecosystem: github-actions
+    directory: /templates/workflows
+    schedule:
+      interval: weekly
+    groups:
+      templates-workflows:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7

--- a/.github/template-files/templates/dependabot_extras.yml
+++ b/.github/template-files/templates/dependabot_extras.yml
@@ -1,0 +1,10 @@
+  - package-ecosystem: github-actions
+    directory: /templates/workflows
+    schedule:
+      interval: weekly
+    groups:
+      templates-workflows:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,8 @@ repos:
         exclude: |
           (?x)^(
             templates/issues/bug.yml|
-            templates/workflows/build.yml|
-            templates/workflows/slow-tests.yml|
-            templates/dependabot.yml
+            templates/dependabot.yml|
+            \.github/template-files/templates/dependabot_extras.yml
           )
       # catch git merge/rebase problems
       - id: check-merge-conflict
@@ -51,9 +50,8 @@ repos:
         exclude: |
           (?x)^(
             templates/issues/bug.yml|
-            templates/workflows/build.yml|
-            templates/workflows/slow-tests.yml|
-            templates/dependabot.yml
+            templates/dependabot.yml|
+            \.github/template-files/templates/dependabot_extras.yml
           )
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.4

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -40,3 +40,4 @@ updates:
         patterns:
           - '*'
   [%- endif %]
+[% include 'dependabot_extras.yml' ignore missing -%]

--- a/templates/workflows/README.md
+++ b/templates/workflows/README.md
@@ -1,0 +1,44 @@
+# Workflow templates
+
+Jinja templates synced to downstream repos via
+[`conda/actions/template-files`](https://github.com/conda/actions/tree/main/template-files).
+Each consumer renders them into `.github/workflows/`.
+
+## When to template here vs. `conda/actions`
+
+These templates work well for small, repo-specific variation (matrix shape, workflow names,
+template variables). If a workflow is getting hard to read, test, or keep YAML-safe, prefer a
+reusable [workflow or composite action in `conda/actions`](https://github.com/conda/actions)
+and call it from a thin workflow template instead.
+
+## YAML-safe Jinja (current conventions)
+
+Dependabot and our pre-commit YAML hooks parse these files **before** Jinja runs. The rules below
+are what we follow today; more complex workflows may need different trade-offs, and this section
+should be updated when they do.
+
+**Block tags** — put `[% ... %]` on a YAML comment line prefixed with `template-files-`:
+
+- `# template-files-if [%- if ... %]`
+- `# template-files-else [%- else %]`
+- `# template-files-endif [%- endif %]`
+- `# template-files-raw [%- raw %]`
+- `# template-files-endraw [%- endraw %]`
+
+Use `raw`/`endraw` around shell that contains `[[ ... ]]`. Rendered workflows keep the
+`# template-files-*` lines; GitHub Actions ignores them.
+
+**Expressions** — do not start an unquoted scalar with `[[ ... ]]`. Use a quoted string or a
+literal block:
+
+```yaml
+      - '[[ tests_workflow | default("Tests") ]]'
+  PLATFORMS: |
+    [[ (platforms | default(['Linux', 'macOS', 'Windows'])) | join('\n    ') ]]
+```
+
+**Conditionals and Dependabot** — both branches of an `if`/`else` remain in the unrendered YAML.
+That is fine when `uses:` pins are not duplicated across branches (as in `build.yml`).
+
+**Pre-commit** — `templates/workflows/*.yml` are checked by `check-yaml` and `yamlfmt`. Other
+Jinja templates (for example `templates/dependabot.yml`) stay excluded.

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -17,7 +17,7 @@ on:
   # Build canaries after a successful test workflow run on main or feature/* branches.
   workflow_run:
     workflows:
-      - [[ tests_workflow | default('Tests') ]]
+      - '[[ tests_workflow | default("Tests") ]]'
     types:
       - completed
 
@@ -82,10 +82,10 @@ jobs:
     strategy:
       matrix:
         include:
-        [%- if noarch is defined and noarch %]
+          # template-files-if [%- if noarch is defined and noarch %]
           - runs-on: ubuntu-latest
             subdir: noarch
-        [%- else %]
+          # template-files-else [%- else %]
           - runs-on: ubuntu-latest
             subdir: linux-64
           - runs-on: ubuntu-24.04-arm
@@ -94,7 +94,7 @@ jobs:
             subdir: osx-arm64
           - runs-on: windows-latest
             subdir: win-64
-        [%- endif %]
+          # template-files-endif [%- endif %]
     runs-on: ${{ matrix.runs-on }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version

--- a/templates/workflows/slow-tests.yml
+++ b/templates/workflows/slow-tests.yml
@@ -86,7 +86,7 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          [%- raw %]
+          # template-files-raw [%- raw %]
           # Verify epic exists and get its node ID, default to dry-run if missing
           if ! epic_id=$(gh issue view "${EPIC_NUMBER}" --json id --jq '.id' 2>/dev/null); then
             echo "::warning::Epic #${EPIC_NUMBER} does not exist. Running in dry-run mode."
@@ -146,14 +146,14 @@ jobs:
           total_count=$(wc -l < /tmp/tracked_tests.txt 2>/dev/null) || total_count=0
           echo "Sub-issues: ${total_count} total, ${incomplete_count} incomplete"
           echo "incomplete_count=${incomplete_count}" >> "$GITHUB_OUTPUT"
-          [%- endraw %]
+          # template-files-endraw [%- endraw %]
 
       - name: Fetch duration files
         id: durations
         env:
           BASE_URL: https://raw.githubusercontent.com/${{ github.repository }}/main/durations
         run: |
-          [%- raw %]
+          # template-files-raw [%- raw %]
           # Combine all durations, keeping max and tracking which platform
           # Format: {test_name: {duration: N, platform: "X"}}
           echo "{}" > /tmp/all_durations.json
@@ -198,7 +198,7 @@ jobs:
 
           echo "platforms_fetched=${fetched:-none}" >> "$GITHUB_OUTPUT"
           echo "platforms_missing=${missing}" >> "$GITHUB_OUTPUT"
-          [%- endraw %]
+          # template-files-endraw [%- endraw %]
 
       - name: Create sub-issues up to cap
         id: create
@@ -207,7 +207,7 @@ jobs:
           INCOMPLETE_COUNT: ${{ steps.epic.outputs.incomplete_count }}
           EPIC_ID: ${{ steps.epic.outputs.epic_id }}
         run: |
-          [%- raw %]
+          # template-files-raw [%- raw %]
           to_add=$((MAX_INCOMPLETE - INCOMPLETE_COUNT))
           if [[ "$to_add" -le 0 ]]; then
             echo "Already at cap (${INCOMPLETE_COUNT} incomplete sub-issues)"
@@ -289,7 +289,7 @@ jobs:
 
           echo "Processed $created tests"
           echo "created_count=$created" >> "$GITHUB_OUTPUT"
-          [%- endraw %]
+          # template-files-endraw [%- endraw %]
 
       - name: Summary
         if: always()
@@ -301,7 +301,7 @@ jobs:
           PLATFORMS_FETCHED: ${{ steps.durations.outputs.platforms_fetched }}
           PLATFORMS_MISSING: ${{ steps.durations.outputs.platforms_missing }}
         run: |
-          [%- raw %]
+          # template-files-raw [%- raw %]
           echo "## Slow Test Review Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [[ "${EPIC_MISSING}" == "true" ]]; then
@@ -330,4 +330,4 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             cat /tmp/created_summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
           fi
-          [%- endraw %]
+          # template-files-endraw [%- endraw %]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Realized both build.yml and slow-tests.yml were no longer receiving dependabot updates:

1. enable dependabot on /templates/workflows by adding support for extending the dependabot per repo with a `.github/template-files/templates/dependabot_extras.yml` stub
2. ensure GH workflow templates are valid YAML files so dependabot can parse them and update accordingly

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
