### PR TITLE
Remove `SYNC_TOKEN` from `update.yml` checkout step

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,9 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ env.REPOSITORY || github.repository }}
-          ref: ${{ env.REF || '' }}
-          token: ${{ secrets.SYNC_TOKEN }}
+          persist-credentials: false
 
       - name: Configure git user
         run: |

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -14,12 +14,6 @@ rules:
       # out any code; it only adds PRs to a GitHub project board.
       - project.yml
 
-  artipacked:
-    ignore:
-      # update.yml needs persisted credentials for the subsequent
-      # git push --force-with-lease step (rendering bot commits).
-      - update.yml
-
   secrets-outside-env:
     ignore:
       # These workflows use repository/org secrets for cross-repo bot


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Don't need a token to checkout the current repo for `schedule` and `workflow_dispatch` triggers.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
