### PR TITLE
Switch `stale.yml` from using `read-yaml` to `read-file`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,10 +40,11 @@ jobs:
             days-before-issue-stale: 90
             days-before-issue-close: 21
     steps:
-      - uses: conda/actions/read-yaml@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
-        id: read_yaml
+      - uses: conda/actions/read-file@7f6830b1428a9bd47f0b068892c77eae95207037 # v26.1.0
+        id: read_messages
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml
+          parser: yaml
 
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         id: stale
@@ -61,7 +62,7 @@ jobs:
           days-before-pr-close: 30
 
           # Comment on the staled issues
-          stale-issue-message: ${{ fromJSON(steps.read_yaml.outputs.value)['stale-issue'] }}
+          stale-issue-message: ${{ fromJSON(steps.read_messages.outputs.content)['stale-issue'] }}
           # Label to apply on staled issues
           stale-issue-label: stale
           # Label to apply on closed issues
@@ -70,7 +71,7 @@ jobs:
           close-issue-reason: not_planned
 
           # Comment on the staled PRs
-          stale-pr-message: ${{ fromJSON(steps.read_yaml.outputs.value)['stale-pr'] }}
+          stale-pr-message: ${{ fromJSON(steps.read_messages.outputs.content)['stale-pr'] }}
           # Label to apply on staled PRs
           stale-pr-label: stale
           # Label to apply on closed PRs


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Dropping `read-yaml` for `read-file` (with `parser: yaml`) so we can deprecate the legacy `read-yaml`.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
