### PR TITLE
Exclude conda/actions from dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+      exclude:
+        - conda/actions
   - package-ecosystem: github-actions
     directory: /templates/workflows
     schedule:
@@ -22,3 +24,5 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+      exclude:
+        - conda/actions

--- a/.github/template-files/templates/dependabot_extras.yml
+++ b/.github/template-files/templates/dependabot_extras.yml
@@ -8,3 +8,5 @@
           - '*'
     cooldown:
       default-days: 7
+      exclude:
+        - conda/actions

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -13,6 +13,8 @@ updates:
           - '*'
     cooldown:
       default-days: 7
+      exclude:
+        - conda/actions
   [%- endif %]
   [%- if pre_commit | default(false) %]
   - package-ecosystem: pre-commit


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Exclude `conda/actions` from Dependabot’s 7-day cooldown. We added the cooldown for third-party actions, but we maintain `conda/actions` and are effectively its only consumers—a cooldown delays fixes (e.g. the recent `combine-durations` bug, https://github.com/conda/actions/pull/478) without meaningful security benefit.

Adds `conda/actions` to dependabot's `cooldown.exclude`. All other third-party actions keep the 7-day cooldown.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
