### PR TITLE
Run and fix actionslint on slow-tests.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,12 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-        exclude: ^\.github/workflows/stale\.yml$
+        files: ^(\.github/workflows/|templates/workflows/)
+        exclude: |
+          (?x)^(
+            \.github/workflows/stale\.yml|
+            templates/workflows/build\.yml
+          )$
   - repo: meta
     # see https://pre-commit.com/#meta-hooks
     hooks:

--- a/templates/workflows/slow-tests.yml
+++ b/templates/workflows/slow-tests.yml
@@ -107,6 +107,8 @@ jobs:
               local after_clause=""
               [[ -n "$cursor" ]] && after_clause=", after: \"$cursor\""
 
+              # GraphQL variables ($owner, etc.) must stay literal inside single quotes
+              # shellcheck disable=SC2016
               response=$(gh api graphql -f query='
                 query($owner: String!, $repo: String!, $number: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -252,12 +254,14 @@ jobs:
               cat /tmp/slow-test-issue.md
               echo "::endgroup::"
               # Save for summary
-              echo "<details>" >> /tmp/dry_run_summary.md
-              echo "<summary>Would create: Review slow test: <code>$test_name</code></summary>" >> /tmp/dry_run_summary.md
-              echo "" >> /tmp/dry_run_summary.md
-              cat /tmp/slow-test-issue.md >> /tmp/dry_run_summary.md
-              echo "</details>" >> /tmp/dry_run_summary.md
-              echo "" >> /tmp/dry_run_summary.md
+              {
+                echo "<details>"
+                echo "<summary>Would create: Review slow test: <code>$test_name</code></summary>"
+                echo ""
+                cat /tmp/slow-test-issue.md
+                echo "</details>"
+                echo ""
+              } >> /tmp/dry_run_summary.md
             else
               # Create issue (returns URL like https://github.com/owner/repo/issues/123)
               issue_url=$(gh issue create \
@@ -271,6 +275,8 @@ jobs:
 
               # GraphQL mutation to add sub-issue to parent epic
               # (gh CLI doesn't support parent issue linking: https://github.com/cli/cli/issues/10298)
+              # GraphQL variables ($parent, $child) must stay literal inside single quotes
+              # shellcheck disable=SC2016
               gh api graphql -f query='
                 mutation($parent: ID!, $child: ID!) {
                   addSubIssue(input: {issueId: $parent, subIssueId: $child}) {
@@ -302,32 +308,34 @@ jobs:
           PLATFORMS_MISSING: ${{ steps.durations.outputs.platforms_missing }}
         run: |
           # template-files-raw [%- raw %]
-          echo "## Slow Test Review Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [[ "${EPIC_MISSING}" == "true" ]]; then
-            echo "**Epic:** #${EPIC_NUMBER} (not found, running as dry run)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "**Epic:** [#${EPIC_NUMBER}](${ISSUES_URL}/${EPIC_NUMBER})" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "**Platforms:** ${PLATFORMS_FETCHED}" >> $GITHUB_STEP_SUMMARY
-          if [[ -n "${PLATFORMS_MISSING}" ]]; then
-            echo "**Missing:** ${PLATFORMS_MISSING}" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "**Incomplete sub-issues before:** ${INCOMPLETE_COUNT}" >> $GITHUB_STEP_SUMMARY
-          echo "**Max allowed:** ${MAX_INCOMPLETE}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Slow Test Review Summary"
+            echo ""
+            if [[ "${EPIC_MISSING}" == "true" ]]; then
+              echo "**Epic:** #${EPIC_NUMBER} (not found, running as dry run)"
+            else
+              echo "**Epic:** [#${EPIC_NUMBER}](${ISSUES_URL}/${EPIC_NUMBER})"
+            fi
+            echo "**Platforms:** ${PLATFORMS_FETCHED}"
+            if [[ -n "${PLATFORMS_MISSING}" ]]; then
+              echo "**Missing:** ${PLATFORMS_MISSING}"
+            fi
+            echo "**Incomplete sub-issues before:** ${INCOMPLETE_COUNT}"
+            echo "**Max allowed:** ${MAX_INCOMPLETE}"
+            echo ""
 
-          if [[ "${CREATED_COUNT}" == "-1" ]]; then
-            echo "**Already at cap, no new sub-issues created**" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${CREATED_COUNT}" == "0" ]]; then
-            echo "**No untracked slow tests found**" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${DRY_RUN}" == "true" ]]; then
-            echo "**Dry run, would create ${CREATED_COUNT} new sub-issue(s)**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            cat /tmp/dry_run_summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
-          else
-            echo "**Created ${CREATED_COUNT} new sub-issue(s)**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            cat /tmp/created_summary.md >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
-          fi
+            if [[ "${CREATED_COUNT}" == "-1" ]]; then
+              echo "**Already at cap, no new sub-issues created**"
+            elif [[ "${CREATED_COUNT}" == "0" ]]; then
+              echo "**No untracked slow tests found**"
+            elif [[ "${DRY_RUN}" == "true" ]]; then
+              echo "**Dry run, would create ${CREATED_COUNT} new sub-issue(s)**"
+              echo ""
+              cat /tmp/dry_run_summary.md 2>/dev/null || true
+            else
+              echo "**Created ${CREATED_COUNT} new sub-issue(s)**"
+              echo ""
+              cat /tmp/created_summary.md 2>/dev/null || true
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
           # template-files-endraw [%- endraw %]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds actionslint to `slow-tests.yml`, but not `build.yml` which is Jinja2 heavy. The motivation for this is that https://github.com/conda/conda/pull/16468 motivated me to turn on actionslint in conda, but the `slow-tests.yml` is failing lint. It fixes the lint on the file using:

1. `>> $GITHUB_STEP_SUMMARY` → one `{ … } >> "$GITHUB_STEP_SUMMARY"` (SC2086 quoting + SC2129 grouping). The echo/cat content is unchanged, only how it’s written to the step summary file.
2. Shellcheck `disable=SC2016` on GraphQL calls since they need to be single-quoted strings with $owner, $parent, etc.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
