### PR TITLE
Add check-news and prepare-release workflow templates

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  templates/workflows/prepare-release.yml:
+    ignore:
+      - ^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,7 +30,7 @@ jobs:
       statuses: write  # Required to publish the CLA commit status.
     steps:
       - name: Check CLA
-        uses: conda/actions/check-cla@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
+        uses: conda/actions/check-cla@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         with:
           # [required]
           # A token with ability to comment, label, and modify the commit status

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,7 +40,7 @@ jobs:
             days-before-issue-stale: 90
             days-before-issue-close: 21
     steps:
-      - uses: conda/actions/read-file@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
+      - uses: conda/actions/read-file@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         id: read_messages
         with:
           path: https://raw.githubusercontent.com/conda/infra/main/.github/messages.yml

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,11 +33,11 @@ jobs:
           git config --global user.name 'Conda Bot'
           git config --global user.email '18747875+conda-bot@users.noreply.github.com'
 
-      - uses: conda/actions/combine-durations@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
+      - uses: conda/actions/combine-durations@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         id: durations
         continue-on-error: true
 
-      - uses: conda/actions/template-files@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
+      - uses: conda/actions/template-files@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         id: templates
         continue-on-error: true
 

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -44,6 +44,17 @@ conda/infrastructure:
   #     platforms:
   #       - Linux
 
+  # [optional] news fragment validation on PRs
+  # - src: templates/workflows/news.yml
+  #   dst: .github/workflows/news.yml
+
+  # [optional] aggregate news fragments into CHANGELOG on release branches
+  # - src: templates/workflows/prepare-release.yml
+  #   dst: .github/workflows/prepare-release.yml
+  # For repos whose test workflow is not named "Tests", add:
+  #   with:
+  #     tests_workflow: Test
+
   # [optional] general processes for the conda org
   - src: templates/HOW_WE_USE_GITHUB.md
     dst: HOW_WE_USE_GITHUB.md
@@ -62,10 +73,12 @@ conda/infrastructure:
     dst: .github/ISSUE_TEMPLATE/epic.yml
 
   # [optional] standard PR template
-  # - src: templates/pull_requests/news_tests_docs.md
-  #   dst: .github/template-files/templates/pull_request_template_details.md
   - src: templates/pull_requests/base.md
     dst: .github/PULL_REQUEST_TEMPLATE.md
+
+  # [optional] extra PR checklist for news fragments, tests, and docs
+  # - src: templates/pull_requests/news_tests_docs.md
+  #   dst: .github/template-files/templates/pull_request_template_details.md
 
   # [optional] dependabot
   # - src: templates/dependabot.yml

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -45,8 +45,8 @@ conda/infrastructure:
   #       - Linux
 
   # [optional] news fragment validation on PRs
-  # - src: templates/workflows/news.yml
-  #   dst: .github/workflows/news.yml
+  # - src: templates/workflows/check-news.yml
+  #   dst: .github/workflows/check-news.yml
 
   # [optional] aggregate news fragments into CHANGELOG on release branches
   # - src: templates/workflows/prepare-release.yml

--- a/templates/workflows/build.yml
+++ b/templates/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@0f4ec1506e74c12799813dc66e613a39077ea864 # v26.7.0
+        uses: conda/actions/canary-release@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         env:
           _CONDA_BUILD_ISOLATED_ACTIVATION: 1
         with:

--- a/templates/workflows/check-news.yml
+++ b/templates/workflows/check-news.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Check News
-        uses: conda/actions/check-news@c1c846fb069313a5850f8bdda8be79e434ccc49f
+        uses: conda/actions/check-news@3bdc06c6ada7ab3906280debdd8873810d9f3435 # v26.8.0
         with:
           skip-label: no-news
           require-pr-number: true

--- a/templates/workflows/check-news.yml
+++ b/templates/workflows/check-news.yml
@@ -1,6 +1,6 @@
 # edit this in [[ source.html_url ]]
 
-name: News fragment
+name: Check news
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  news:
+  check-news:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout Source

--- a/templates/workflows/news.yml
+++ b/templates/workflows/news.yml
@@ -1,0 +1,34 @@
+# edit this in [[ source.html_url ]]
+
+name: News fragment
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  news:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check News
+        uses: conda/actions/check-news@c1c846fb069313a5850f8bdda8be79e434ccc49f
+        with:
+          skip-label: no-news
+          require-pr-number: true
+          news-directory: news

--- a/templates/workflows/prepare-release.yml
+++ b/templates/workflows/prepare-release.yml
@@ -1,0 +1,34 @@
+# edit this in [[ source.html_url ]]
+
+name: Prepare release notes
+
+on:
+  workflow_run:
+    workflows:
+      - '[[ tests_workflow | default("Tests") ]]'
+    types:
+      - completed
+    branches:
+      - '[0-9].*.x'
+      - '[0-9][0-9].*.x'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-slim
+    steps:
+      - name: Prepare Release Notes
+        uses: conda/actions/prepare-release@c1c846fb069313a5850f8bdda8be79e434ccc49f
+        with:
+          news-directory: news
+          changelog-path: CHANGELOG.md
+          release-branch-pattern: |
+            [0-9].*.x
+            [0-9][0-9].*.x

--- a/templates/workflows/prepare-release.yml
+++ b/templates/workflows/prepare-release.yml
@@ -12,6 +12,11 @@ on:
       - '[0-9].*.x'
       - '[0-9][0-9].*.x'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  queue: max
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/templates/workflows/prepare-release.yml
+++ b/templates/workflows/prepare-release.yml
@@ -13,8 +13,7 @@ on:
       - '[0-9][0-9].*.x'
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   prepare:
@@ -27,6 +26,7 @@ jobs:
       - name: Prepare Release Notes
         uses: conda/actions/prepare-release@c1c846fb069313a5850f8bdda8be79e434ccc49f
         with:
+          token: ${{ secrets.SYNC_TOKEN }}
           news-directory: news
           changelog-path: CHANGELOG.md
           release-branch-pattern: |

--- a/templates/workflows/prepare-release.yml
+++ b/templates/workflows/prepare-release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Prepare Release Notes
-        uses: conda/actions/prepare-release@c1c846fb069313a5850f8bdda8be79e434ccc49f
+        uses: conda/actions/prepare-release@3bdc06c6ada7ab3906280debdd8873810d9f3435 #v26.8.0
         with:
           token: ${{ secrets.SYNC_TOKEN }}
           news-directory: news


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Following https://github.com/conda/actions/pull/459/, this PR adds check-news and prepare-release workflow templates that downstream projects can opt in to.



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/infrastructure/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/infrastructure/blob/main/CONTRIBUTING.md -->
